### PR TITLE
fix(platforms): add missing `fds` entry to `platforms` table

### DIFF
--- a/helpers/muos.lua
+++ b/helpers/muos.lua
@@ -52,6 +52,7 @@ local muos = {
     ["gba"] = "Nintendo Game Boy Advance",
     ["gbc"] = "Nintendo Game Boy Color",
     ["n64"] = "Nintendo N64",
+    ["fds"] = "Nintendo NES-Famicom",
     ["nes"] = "Nintendo NES-Famicom",
     ["pokemini"] = "Nintendo Pokemon Mini",
     ["snes"] = "Nintendo SNES-SFC",


### PR DESCRIPTION
Famicom Disk System (FDS) catalogue location lookup was failing due to it missing an entry in the `platforms` table. In muOS, FDS shares the same core assignement as NES, so this maps FDS to the same catalogue location as NES.