### PR TITLE
feat: added cache backup option

### DIFF
--- a/lib/backup_cache_backend.lua
+++ b/lib/backup_cache_backend.lua
@@ -1,0 +1,27 @@
+require("globals")
+local parser = require("lib.parser")
+local log = require("lib.log")
+local utils = require("helpers.utils")
+
+local cache_backup_channel = love.thread.getChannel("cache_backup")
+local running = true
+
+while running do
+  log.write("Starting Zip to compress and move cache folder")
+  local stderr_to_stdout = " 2>&1"
+  local command = 'zip -r /mnt/sdcard/ARCHIVE/scrappy_cache-$(date +"%Y-%m-%d-%H-%M-%S").zip /mnt/mmc/MUOS/application/.scrappy/data/cache/'
+  local output = io.popen(command .. stderr_to_stdout)
+
+  if not output then
+    log.write("Failed to run Zip")
+    cache_backup_channel:push({ data = {}, error = "Failed to run Zip", loading = false })
+    running = false
+  end
+
+  for line in output:lines() do
+    if line:find("adding") then
+      cache_backup_channel:push({ command_finished = true })
+      running = false
+    end
+  end
+end


### PR DESCRIPTION
I've added an option to backup cache folder to SD2/Archive using zip OS command.
This allow users to backup cache before flashing SD1 where scrappy cache is stored.
Backed up cache can be restored using muOS Archive Manager