### PR TITLE
Add support for preview output type and relative layout and fix for box2d padding

### DIFF
--- a/scenes/tools.lua
+++ b/scenes/tools.lua
@@ -14,7 +14,7 @@ local tools               = {}
 local theme               = configs.theme
 local scraper_opts        = { "screenscraper", "thegamesdb" }
 local scraper_index       = 1
-local output_opts         = { "box", "splash" }
+local output_opts         = { "box", "splash", "preview" }
 local output_index        = 1
 
 local w_width, w_height   = love.window.getMode()

--- a/templates/box2d.xml
+++ b/templates/box2d.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <artwork>
-  <output type="cover" height="240">
-    <layer resource="cover" height="240" x="-20" y="0" valign="center">
+  <output type="cover" width="220">
+    <layer resource="cover" width="200" x="0" y="0" valign="center">
       <shadow distance="5" softness="5" opacity="70"/>
     </layer>
   </output>

--- a/templates/preview_screenshot.xml
+++ b/templates/preview_screenshot.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<artwork>
+  <output type="cover" width="640" height="480">
+    <layer resource="screenshot" width="640" height="480">
+    </layer> 
+  </output>
+</artwork>


### PR DESCRIPTION
Hi,
muOS supports preview as output time, I've added the option to generate this kind of resource too.
I've added a simple "preview" template too, it contains only the screenshot.