### PR TITLE
Update to artwork.lua to support screenshot copy

### DIFF
--- a/helpers/artwork.lua
+++ b/helpers/artwork.lua
@@ -8,6 +8,7 @@ local pprint   = require("lib.pprint")
 local artwork  = {
   cached_game_ids = {},
   output_type = "box",
+  output_type_preview = "preview",  
 }
 
 
@@ -50,13 +51,16 @@ function artwork.copy_to_catalogue(platform, game)
     return
   end
   output_path = utils.strip_quotes(output_path)
-  local path = string.format("%s/%s/media/covers/%s.png", output_path, platform, game)
   local destination_folder = muos.platforms[platform]
   if not destination_folder then
     log.write("Catalogue destination folder not found")
     return
   end
 
+  -----------------------------
+  -- Copy box/cover artwork
+  -----------------------------
+  local path = string.format("%s/%s/media/covers/%s.png", output_path, platform, game) 
   local scraped_art = nativefs.newFileData(path)
   if not scraped_art then
     log.write("Scraped artwork not found")
@@ -68,7 +72,25 @@ function artwork.copy_to_catalogue(platform, game)
   if err then
     log.write(err)
   end
+  
+  -----------------------------
+  -- Copy screenshot/preview artwork
+  -----------------------------
+  path = string.format("%s/%s/media/screenshots/%s.png", output_path, platform, game)
+  scraped_art = nativefs.newFileData(path)
+  if not scraped_art then
+    log.write("Scraped screenshot artwork not found")
+  else
+    output_folder = string.format("%s/%s/%s", catalogue_path, destination_folder, artwork.output_type_preview)
+    local _, err = nativefs.write(string.format("%s/%s.png", output_folder, game), scraped_art)
+    if err then
+      log.write(err)
+    end
+  end
 
+  -----------------------------
+  -- Create text file
+  -----------------------------
   local xml = nativefs.read(string.format("%s/%s/gamelist.xml", output_path, platform))
   if xml then
     local list = gamelist.parse(xml)


### PR DESCRIPTION
Changes to copy cached screenshot artwork to the preview folder.
Fixes https://github.com/gabrielfvale/scrappy/issues/12.

In order for the proposed codes changes to work, a modification to the template file being used will need to be made. For the template file you are using (located in folder "/mmc/MUOS/application/.scrappy/templates") add a line like the one below after the "cover" output node (first ...)

`<output type="screenshot" width="640" height="480" />`
This tells Skyscraper to download screenshot artwork for each game. Note, select the width/height or mpixels values appropriate for your device.

Example template file:

`<?xml version="1.0" encoding="UTF-8"?> <artwork> <output type="cover" width="640" height="480"> <layer resource="screenshot" width="640" height="480" align="center" valign="middle" opacity="100"> </layer> <mask width="640" height="480" file="mask/BlackGradientShadow.png"/> <layer resource="cover" width="120" x="-16" y="-60" valign="bottom" align="right"> <rounded radius="7"/> <stroke width="5" red="255" green="255" blue="255"/> <shadow distance="5" softness="5" opacity="70"/> </layer> </output> <output type="screenshot" width="640" height="480" /> </artwork>`