### PR TITLE
adding bin format to psx peas.json

### DIFF
--- a/static/.skyscraper/peas.json
+++ b/static/.skyscraper/peas.json
@@ -1912,6 +1912,7 @@
             "sony playstation"
         ],
         "formats": [
+            "*.bin",
             "*.cbn",
             "*.chd",
             "*.cue",


### PR DESCRIPTION
Looking to have .bin files get scrapped too in scenarios where single track bin files are playable unaccompanied by their .cue counterparts. Example -> Tony Hawk's Pro Skater 2 has a single track and single index within its .cue file. 

```txt
FILE "Tony Hawk's Pro Skater 2 (USA).bin" BINARY
  TRACK 01 MODE2/2352
    INDEX 01 00:00:00
```